### PR TITLE
Ad open after savebuttom

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,7 @@
       <map>
         <entry key="..\:/Kotlin-Projeto/paylip-app/app/src/main/res/layout/activity_main.xml" value="0.30520833333333336" />
         <entry key="..\:/Kotlin-Projeto/paylip-app/app/src/main/res/layout/activity_result_acitivity.xml" value="0.30520833333333336" />
+        <entry key="..\:/TP7/paylip-app/app/src/main/res/layout/activity_result_acitivity.xml" value="0.1" />
         <entry key="..\:/Users/cahca/AndroidStudioProjects/paylip-app/app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.1" />
         <entry key="..\:/Users/cahca/AndroidStudioProjects/paylip-app/app/src/main/res/drawable/ic_launcher_background.xml" value="0.1" />
         <entry key="..\:/Users/cahca/AndroidStudioProjects/paylip-app/app/src/main/res/layout/activity_main.xml" value="0.22" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,4 +40,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    //dependencia do anuncio
+    implementation 'com.google.android.gms:play-services-ads:21.2.0'
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,6 +37,14 @@
         <meta-data
             android:name="preloaded_fonts"
             android:resource="@array/preloaded_fonts" />
+
+        <!--
+        chamada ao google ads
+        Sample AdMob app ID: ca-app-pub-3940256099942544~3347511713 -->
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713"/>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/br/edu/infnet/paylipapp/ResultAcitivity.kt
+++ b/app/src/main/java/br/edu/infnet/paylipapp/ResultAcitivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.os.Environment
 import android.provider.Settings
 import android.util.Log
+import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
@@ -17,10 +18,19 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import com.google.android.gms.ads.*
+import com.google.android.gms.ads.interstitial.InterstitialAd
+import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
+import com.google.android.gms.ads.rewarded.RewardedAd
+import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import java.io.*
 import java.util.*
 
 class ResultAcitivity : AppCompatActivity() {
+    //Anuncio somente ao clicar no botão salvar
+    private var _interstitialAd: InterstitialAd? = null
+    private var _bannerAd: AdView? = null
+
     private companion object{
         //PERMISSION request constant, assign any value
         private const val STORAGE_PERMISSION_CODE = 100
@@ -64,14 +74,47 @@ class ResultAcitivity : AppCompatActivity() {
             intent.putExtra("etOthers", others)
 
             if (checkPermission()){
-                Log.d(ResultAcitivity.TAG, "onCreate: Permission already granted, create folder")
+                Log.d(TAG, "onCreate: Permission already granted, create folder")
                 saveToFile(salary, dependents, alimony, others)
             }
             else{
-                Log.d(ResultAcitivity.TAG, "onCreate: Permission was not granted, request")
+                Log.d(TAG, "onCreate: Permission was not granted, request")
                 requestPermission()
             }
+
+            //inicia o banner e suas configurações para mostrar em tela
+            MobileAds.initialize(this)
+            loadInterstitial()
+            loadBannerAd()
+
         }
+
+    }
+
+    //carrega o tipo de anuncio
+    private fun loadInterstitial() {
+        val adRequest = AdRequest.Builder().build()
+        InterstitialAd.load(this, "ca-app-pub-3940256099942544/1033173712", adRequest, object : InterstitialAdLoadCallback() {
+            override fun onAdFailedToLoad(adError: LoadAdError) {
+                _interstitialAd = null;
+            }
+
+            override fun onAdLoaded(interstitialAd: InterstitialAd) {
+                _interstitialAd = interstitialAd
+            }
+        })
+    }
+
+    //carrega a propaganda
+    private fun loadBannerAd() {
+        _bannerAd = findViewById(R.id.adView)
+        val adRequest = AdRequest.Builder().build()
+        _bannerAd?.loadAd(adRequest)
+    }
+
+    //mostra o tipo de anuncio
+    fun showInterstitial(view: View) {
+        _interstitialAd?.show(this)
     }
 
     private fun liquidSalary(){

--- a/app/src/main/res/layout/activity_result_acitivity.xml
+++ b/app/src/main/res/layout/activity_result_acitivity.xml
@@ -287,12 +287,25 @@
         android:text="@string/save"
         android:textColor="#4C1F02"
         android:textStyle="bold"
+        android:onClick="showInterstitial"
         app:iconTint="#9E9D24"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/adView"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/btDelete"
         app:layout_constraintVertical_bias="0.052" />
+
+    <!-- Configuração da view do anúncio-->
+    <com.google.android.gms.ads.AdView
+        xmlns:ads="http://schemas.android.com/apk/res-auto"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/adView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        ads:adSize="BANNER"
+        ads:adUnitId="ca-app-pub-3940256099942544/6300978111" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
**Adição do anúncio a tela de Resultado**
Após o clique do botão salvar aparece o anúncio no rodapé de maneira a não interferir na navegação do usuário.
Necessários testes de validação:
O ad demora a carregar

![image](https://user-images.githubusercontent.com/64960807/189065738-1508bdf4-65c6-40d2-bd15-075b205e7e7f.png)


Sugestão para discussão:
- Quando o usuário aceita os termos ele volta a página para calcular
- Talvez seja melhor adicionar a ad após o clique no botão calcular na main
- Será necessário refatoração do código para organizar melhor as informação
- Será necessário mais comentários no código afim de melhor compreensão